### PR TITLE
fix(client): keys keep the "most correct" color

### DIFF
--- a/react-wordle/src/lib/statuses.ts
+++ b/react-wordle/src/lib/statuses.ts
@@ -3,43 +3,47 @@ import { GuessedWord } from './localStorage'
 export type CharStatus = 'absent' | 'present' | 'correct'
 
 export const getStatuses = (
-    guesses: GuessedWord[]
+  guesses: GuessedWord[]
 ): { [key: string]: CharStatus } => {
-    const charObj: { [key: string]: CharStatus } = {}
+  const charObj: { [key: string]: CharStatus } = {}
 
-    guesses.forEach((word) => {
-        word.forEach((guessedChar) => {
-            if (guessedChar.mpcResult === "wrong") {
-                // make status absent
-                return (charObj[guessedChar.char] = 'absent')
-            }
+  guesses.forEach((word) => {
+    word.forEach((guessedChar) => {
+      if (guessedChar.mpcResult === "correct") {
+        //make status correct
+        return (charObj[guessedChar.char] = 'correct')
+      }
 
-            if (guessedChar.mpcResult === "correct") {
-                //make status correct
-                return (charObj[guessedChar.char] = 'correct')
-            }
+      if (guessedChar.mpcResult === "wrongPosition" && charObj[guessedChar.char] !== 'correct') {
+        //make status present
+        return (charObj[guessedChar.char] = 'present')
+      }
 
-            if (guessedChar.mpcResult === "wrongPosition") {
-                //make status present
-                return (charObj[guessedChar.char] = 'present')
-            }
-        })
+      if (
+        guessedChar.mpcResult === "wrong" &&
+        charObj[guessedChar.char] !== 'correct' &&
+        charObj[guessedChar.char] !== 'present'
+      ) {
+        // make status absent
+        return (charObj[guessedChar.char] = 'absent')
+      }
     })
+  })
 
-    return charObj
+  return charObj
 }
 
 export const getGuessStatuses = (
-    guess: GuessedWord
+  guess: GuessedWord
 ): CharStatus[] => {
-    return guess.map((guessedChar) => {
-        switch (guessedChar.mpcResult) {
-            case "correct":
-                return 'correct' as CharStatus
-            case "wrongPosition":
-                return 'present' as CharStatus
-            default:
-                return 'absent' as CharStatus
-        }
-    })
+  return guess.map((guessedChar) => {
+    switch (guessedChar.mpcResult) {
+      case "correct":
+        return 'correct' as CharStatus
+      case "wrongPosition":
+        return 'present' as CharStatus
+      default:
+        return 'absent' as CharStatus
+    }
+  })
 }


### PR DESCRIPTION
If a key turns green once, it won't turn yellow nor gray anymore;
If a key turns yellow once, it won't turn gray anymore:

<img width="514" alt="Screenshot 2022-10-27 at 16 03 53" src="https://user-images.githubusercontent.com/100690574/198326547-744b3794-8048-4ec3-ac83-df22f15f9eb5.png">

Please note: `getStatuses` is only used in the `Keyboard` component, which is why this change doesn't break anything in the `Grid`. Since that was the case, it seemed to be the cleanest solution.